### PR TITLE
Expose Noah DTBL

### DIFF
--- a/drivers/erf/NoahmpIO.H
+++ b/drivers/erf/NoahmpIO.H
@@ -16,6 +16,8 @@ extern "C" {
         int *rank, *blkid, *level;
         int *comm;
 
+        double* DTBL = nullptr;       // Timestep 
+
         double* XLAT = nullptr;       // latitude [rad]
         double* WSLAKEXY = nullptr;   // lake water storage [mm]
         double* U_PHY = nullptr;
@@ -41,14 +43,14 @@ extern "C" {
           int* its, int* ite, int* jts, int* jte, int* kts, int* kte,
           int* xstart, int* xend, int* ystart, int* yend, int* itimestep,
           int* ntime, int* nsoil, int* nsnow, int* rank,
-          int* blkid, int* level, int *comm
+          int* blkid, int* level, int *comm, double* DTBL
         ):
           ids(ids), ide(ide), jds(jds), jde(jde), kds(kds), kde(kde),
           ims(ims), ime(ime), jms(jms), jme(jme), kms(kms), kme(kme),
           its(its), ite(ite), jts(jts), jte(jte), kts(kts), kte(kte),
           xstart(xstart), xend(xend), ystart(ystart), yend(yend), itimestep(itimestep),
           ntime(ntime), nsoil(nsoil), nsnow(nsnow), rank(rank), blkid(blkid), 
-          level(level), comm(comm) {}
+          level(level), comm(comm), DTBL(DTBL) {}
     };
 }
 
@@ -64,6 +66,8 @@ class NoahmpIO_type {
         int rank, blkid, level;
         int comm;
 
+        double DTBL;
+    
         NoahArray2D<double> XLAT;
         NoahArray2D<double> WSLAKEXY;
         NoahArray3D<double> U_PHY;
@@ -87,7 +91,8 @@ class NoahmpIO_type {
                &ims, &ime, &jms, &jme, &kms, &kme,
                &its, &ite, &jts, &jte, &kts, &kte,
                &xstart, &xend, &ystart, &yend, &itimestep,
-               &ntime, &nsoil, &nsnow, &rank, &blkid, &level, &comm) {}
+               &ntime, &nsoil, &nsnow, &rank, &blkid,
+               &level, &comm, &DTBL) {}
 
         void ScalarInitDefault();
         void VarInitDefault();

--- a/drivers/erf/NoahmpIOVarType.F90
+++ b/drivers/erf/NoahmpIOVarType.F90
@@ -74,7 +74,7 @@ module NoahmpIOVarType
     integer                                                ::  IOPT_WETLAND        ! wetland model option (0->off; 1->Zhang2022 fixed parameter; 2->Zhang2022 read in 2D parameter)
     real(kind=kind_noahmp)                                 ::  XICE_THRESHOLD      ! fraction of grid determining seaice
     real(kind=kind_noahmp)                                 ::  JULIAN              ! Julian day
-    real(kind=kind_noahmp)                                 ::  DTBL                ! timestep [s]
+    real(kind=C_DOUBLE), pointer                           ::  DTBL                ! timestep [s]
     real(kind=kind_noahmp)                                 ::  DX                  ! horizontal grid spacing [m]
     real(kind=kind_noahmp)                                 ::  soiltstep           ! soil time step (s) (default=0: same as main NoahMP timstep)
     logical                                                ::  FNDSNOWH            ! snow depth present in input

--- a/drivers/erf/NoahmpIO_fi.F90
+++ b/drivers/erf/NoahmpIO_fi.F90
@@ -47,6 +47,7 @@ module NoahmpIO_fi
     type(C_PTR) :: itimestep, ntime
     type(C_PTR) :: rank, blkid, level
     type(C_PTR) :: comm
+    type(C_PTR) :: DTBL
     type(C_PTR) :: XLAT, WSLAKEXY
     type(C_PTR) :: U_PHY, T_PHY, V_PHY, QV_CURR
     type(C_PTR) :: HFX, LH
@@ -104,6 +105,8 @@ contains
 
     call C_F_POINTER(NoahmpIO_cptr%RANK, NoahmpIO_vect(level)%NoahmpIO(bid)%RANK)
     call C_F_POINTER(NoahmpIO_cptr%COMM, NoahmpIO_vect(level)%NoahmpIO(bid)%COMM)
+
+    call C_F_POINTER(NoahmpIO_cptr%DTBL, NoahmpIO_vect(level)%NoahmpIO(bid)%DTBL)
 
   end subroutine NoahmpIOScalarInitDefault_fi
 


### PR DESCRIPTION
# Summary
This PR exposes the noah `DTBL` variable for use in ERF. Exposing this variable allows for sanity checking of the timesteps in noah vs ERF as well as allow sub-stepping of ERF.